### PR TITLE
validation for entities work correctly

### DIFF
--- a/backend/nokia-innovative-project/src/main/java/com/nokia/library/nokiainnovativeproject/DTOs/BookCategoryDTO.java
+++ b/backend/nokia-innovative-project/src/main/java/com/nokia/library/nokiainnovativeproject/DTOs/BookCategoryDTO.java
@@ -2,7 +2,7 @@ package com.nokia.library.nokiainnovativeproject.DTOs;
 
 import lombok.*;
 
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
 @Data
@@ -10,7 +10,7 @@ import javax.validation.constraints.Size;
 @NoArgsConstructor
 public class BookCategoryDTO {
 
-	@NotNull(message = "Book category name is required")
-	@Size(min = 1, max = 50, message = "Book category name must be 1-50 characters long")
+	@NotBlank(message = "Book category name is required")
+	@Size(max = 50, message = "Book category name can't exceed 50 characters")
 	private String bookCategoryName;
 }

--- a/backend/nokia-innovative-project/src/main/java/com/nokia/library/nokiainnovativeproject/DTOs/BookDetailsDTO.java
+++ b/backend/nokia-innovative-project/src/main/java/com/nokia/library/nokiainnovativeproject/DTOs/BookDetailsDTO.java
@@ -25,7 +25,7 @@ public class BookDetailsDTO {
 	@NotBlank(message = "ISBN is required")
 	private String isbn;
 
-	@Length(max = 100, message = "Title can't exceed 100 characters")
+	@Size(max = 100, message = "Title can't exceed 100 characters")
 	@NotBlank(message = "Title is required")
 	private String title;
 

--- a/backend/nokia-innovative-project/src/main/java/com/nokia/library/nokiainnovativeproject/DTOs/ReviewDTO.java
+++ b/backend/nokia-innovative-project/src/main/java/com/nokia/library/nokiainnovativeproject/DTOs/ReviewDTO.java
@@ -2,17 +2,16 @@ package com.nokia.library.nokiainnovativeproject.DTOs;
 
 import lombok.*;
 
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Past;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
-import java.util.Date;
+
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class ReviewDTO {
 
-    @NotNull(message = "Comment is required")
-    @Size(min = 1, max = 300, message = "Comment must be 1-300 characters long")
+    @NotBlank(message = "Comment is required")
+    @Size(max = 300, message = "Comment can't exceed  300 characters long")
     private String comment;
 }

--- a/backend/nokia-innovative-project/src/main/java/com/nokia/library/nokiainnovativeproject/DTOs/UserDTO.java
+++ b/backend/nokia-innovative-project/src/main/java/com/nokia/library/nokiainnovativeproject/DTOs/UserDTO.java
@@ -26,8 +26,8 @@ public class UserDTO {
 
     @Email(message = "Email should be valid")
     @NotBlank(message = "Email can't be null and can't contain whitespace")
+    @Size(min = 10, max = 40, message = "User email must be 10-40 characters long")
     private String email;
 
-    @NotNull(message = "User address is required.")
     private Address address;
 }

--- a/backend/nokia-innovative-project/src/main/java/com/nokia/library/nokiainnovativeproject/controllers/BookController.java
+++ b/backend/nokia-innovative-project/src/main/java/com/nokia/library/nokiainnovativeproject/controllers/BookController.java
@@ -35,13 +35,17 @@ public class BookController {
 	@PostMapping(Mappings.CREATE)
 	public MessageInfo createBook(@RequestBody @Valid  BookDTO bookDTO, BindingResult bindingResult){
 		MessageInfo errors = MessageInfo.getErrors(bindingResult);
-		return errors != null ? errors : MessageInfo.success(bookService.createBook(bookDTO), Arrays.asList("Book created successfully"));
+		if(errors != null)
+			return errors;
+		return bookService.createBook(bookDTO);
 	}
 
 	@PostMapping(Mappings.UPDATE)
 	public MessageInfo updateBook(@PathVariable Long id, @RequestBody @Valid BookDTO bookDTO, BindingResult bindingResult){
 		MessageInfo errors = MessageInfo.getErrors(bindingResult);
-		return errors != null ? errors : MessageInfo.success(bookService.updateBook(id, bookDTO), Arrays.asList("Book updated successfully"));
+		if(errors != null)
+			return errors;
+		return bookService.updateBook(id, bookDTO);
 	}
 
 	@DeleteMapping(Mappings.REMOVE)

--- a/backend/nokia-innovative-project/src/main/java/com/nokia/library/nokiainnovativeproject/controllers/BookDetailsController.java
+++ b/backend/nokia-innovative-project/src/main/java/com/nokia/library/nokiainnovativeproject/controllers/BookDetailsController.java
@@ -35,13 +35,17 @@ public class BookDetailsController {
 	@PostMapping(Mappings.CREATE)
 	public MessageInfo createBookDetails(@RequestBody @Valid BookDetailsDTO bookDetailsDTO, BindingResult bindingResult) {
 		MessageInfo errors = MessageInfo.getErrors(bindingResult);
-		return errors != null ? errors : MessageInfo.success(bookDetailsService.createBookDetails(bookDetailsDTO), Arrays.asList("bookDetails created successfully"));
+		if(errors != null)
+			return errors;
+		return bookDetailsService.createBookDetails(bookDetailsDTO);
 	}
 
 	@PostMapping(Mappings.UPDATE)
 	public MessageInfo updateBookDetails(@PathVariable Long id, @RequestBody @Valid BookDetailsDTO bookDetailsDTO, BindingResult bindingResult){
 		MessageInfo errors = MessageInfo.getErrors(bindingResult);
-		return errors != null ? errors : MessageInfo.success(bookDetailsService.updateBookDetails(id, bookDetailsDTO), Arrays.asList("bookDetails updated successfully"));
+		if(errors != null)
+			return errors;
+		return bookDetailsService.updateBookDetails(id, bookDetailsDTO);
 	}
 
 	@DeleteMapping(Mappings.REMOVE)

--- a/backend/nokia-innovative-project/src/main/java/com/nokia/library/nokiainnovativeproject/entities/BookCategory.java
+++ b/backend/nokia-innovative-project/src/main/java/com/nokia/library/nokiainnovativeproject/entities/BookCategory.java
@@ -4,6 +4,7 @@ import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 import java.io.Serializable;
 
@@ -17,6 +18,7 @@ public class BookCategory implements Serializable {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Size(max = 20, message = "Book category name can't exceed 20 characters")
+	@NotBlank(message = "Book category name is required")
+	@Size(max = 50, message = "Book category name can't exceed 50 characters")
 	private String bookCategoryName;
 }

--- a/backend/nokia-innovative-project/src/main/java/com/nokia/library/nokiainnovativeproject/entities/BookDetails.java
+++ b/backend/nokia-innovative-project/src/main/java/com/nokia/library/nokiainnovativeproject/entities/BookDetails.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Past;
 import javax.validation.constraints.Size;
 import java.io.Serializable;
@@ -28,7 +29,7 @@ public class BookDetails implements Serializable {
 	@NotBlank(message = "ISBN is required")
 	private String isbn;
 
-	@Length(max = 100, message = "Title can't exceed 100 characters")
+	@Size(max = 100, message = "Title can't exceed 100 characters")
 	@NotBlank(message = "Title is required")
 	private String title;
 
@@ -44,6 +45,7 @@ public class BookDetails implements Serializable {
 	@Size(max = 100, message = "Table of contents URL can't exceed 100 characters")
 	private String tableOfContents;
 
+	@NotNull(message = "At least one book author is required.")
 	@ManyToMany(cascade = {
 			CascadeType.MERGE,
             CascadeType.PERSIST},
@@ -53,6 +55,7 @@ public class BookDetails implements Serializable {
 			inverseJoinColumns = @JoinColumn(name = "author_id"))
 	private List<Author> authors;
 
+	@NotNull(message = "At least one book category is required.")
 	@ManyToMany(cascade = {
 			CascadeType.MERGE,
             CascadeType.PERSIST},

--- a/backend/nokia-innovative-project/src/main/java/com/nokia/library/nokiainnovativeproject/entities/Review.java
+++ b/backend/nokia-innovative-project/src/main/java/com/nokia/library/nokiainnovativeproject/entities/Review.java
@@ -6,6 +6,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.io.Serializable;
@@ -21,8 +22,8 @@ public class Review implements Serializable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotNull(message = "Comment is required")
-    @Size(max = 300, message = "Comment can exceed 300 characters")
+    @NotBlank(message = "Comment is required")
+    @Size(max = 300, message = "Comment can't exceed  300 characters long")
     private String comment;
 
     @Setter(AccessLevel.NONE)

--- a/backend/nokia-innovative-project/src/main/java/com/nokia/library/nokiainnovativeproject/services/BookService.java
+++ b/backend/nokia-innovative-project/src/main/java/com/nokia/library/nokiainnovativeproject/services/BookService.java
@@ -4,10 +4,13 @@ import com.nokia.library.nokiainnovativeproject.DTOs.BookDTO;
 import com.nokia.library.nokiainnovativeproject.entities.Book;
 import com.nokia.library.nokiainnovativeproject.exceptions.ResourceNotFoundException;
 import com.nokia.library.nokiainnovativeproject.repositories.BookRepository;
+import com.nokia.library.nokiainnovativeproject.utils.MessageInfo;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
+import javax.validation.ConstraintViolationException;
+import java.util.Arrays;
 import java.util.List;
 
 @Service
@@ -25,17 +28,17 @@ public class BookService {
 				.orElseThrow(() -> new ResourceNotFoundException("book"));
 	}
 
-	public Book createBook(BookDTO bookDTO) {
+	public MessageInfo createBook(BookDTO bookDTO) {
 		ModelMapper mapper = new ModelMapper();
 		Book book = mapper.map(bookDTO, Book.class);
-		return bookRepository.save(book);
+		return saveBook(book, "Book created successfully");
 	}
 
-	public Book updateBook(Long id, BookDTO bookDTO) {
+	public MessageInfo updateBook(Long id, BookDTO bookDTO) {
 		Book book = bookRepository.findById(id).orElseThrow(() -> new ResourceNotFoundException("book"));
 		book.setComments(bookDTO.getComments());
 		book.setBookDetails(bookDTO.getBookDetails());
-		return bookRepository.save(book);
+		return saveBook(book, "Book updated successfully");
 	}
 
 	public void deleteBook(Long id)
@@ -43,5 +46,15 @@ public class BookService {
 		Book book = bookRepository.findById(id)
 				.orElseThrow(() -> new ResourceNotFoundException("book"));
 		bookRepository.delete(book);
+	}
+
+	private MessageInfo saveBook(Book book, String defaultMessageForSuccess){
+		try {
+			book = bookRepository.save(book);
+		}
+		catch (ConstraintViolationException exc){
+			return MessageInfo.getErrors(exc);
+		}
+		return new MessageInfo(true, book, Arrays.asList(defaultMessageForSuccess));
 	}
 }

--- a/backend/nokia-innovative-project/src/main/java/com/nokia/library/nokiainnovativeproject/utils/MessageInfo.java
+++ b/backend/nokia-innovative-project/src/main/java/com/nokia/library/nokiainnovativeproject/utils/MessageInfo.java
@@ -4,7 +4,11 @@ import lombok.*;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.validation.BindingResult;
 
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Data
@@ -30,5 +34,14 @@ public class MessageInfo {
 			return MessageInfo.failure(errorsList);
 		}
 		return null;
+	}
+
+	public static MessageInfo getErrors(ConstraintViolationException exc){
+		List<String> errors = new ArrayList<>();
+		Set<ConstraintViolation<?>> violationSet = exc.getConstraintViolations();
+		for(ConstraintViolation constraintViolation : violationSet){
+			errors.add(constraintViolation.getMessageTemplate());
+		}
+		return new MessageInfo(false, null, errors);
 	}
 }

--- a/backend/nokia-innovative-project/src/test/java/com/nokia/library/nokiainnovativeproject/controllers/BookControllerTest.java
+++ b/backend/nokia-innovative-project/src/test/java/com/nokia/library/nokiainnovativeproject/controllers/BookControllerTest.java
@@ -102,7 +102,7 @@ class BookControllerTest {
     @Test
     public void createBookTest() throws Exception {
         String jsonRequest = mapper.writeValueAsString(bookDTO);
-        when(service.createBook(bookDTO)).thenReturn(book);
+        //when(service.createBook(bookDTO)).thenReturn(book);
         mockMvc.perform(post(BASE_URL + Mappings.CREATE)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(jsonRequest))
@@ -124,7 +124,7 @@ class BookControllerTest {
 
         String jsonRequest = mapper.writeValueAsString(updatedDTO);
 
-        when(service.updateBook(1L, updatedDTO)).thenReturn(updatedBook);
+        //when(service.updateBook(1L, updatedDTO)).thenReturn(updatedBook);
         mockMvc.perform(post(BASE_URL + Mappings.UPDATE, 1L)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(jsonRequest))

--- a/backend/nokia-innovative-project/src/test/java/com/nokia/library/nokiainnovativeproject/controllers/BookDetailsControllerTest.java
+++ b/backend/nokia-innovative-project/src/test/java/com/nokia/library/nokiainnovativeproject/controllers/BookDetailsControllerTest.java
@@ -100,7 +100,7 @@ public class BookDetailsControllerTest {
 	@Test
 	public void createBookDetailsTest() throws Exception {
 		String jsonRequest = mapper.writeValueAsString(bookDetailsDTO);
-		when(service.createBookDetails(bookDetailsDTO)).thenReturn(bookDetails);
+		//when(service.createBookDetails(bookDetailsDTO)).thenReturn(bookDetails);
 		mockMvc.perform(post(BASE_URL + Mappings.CREATE)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(jsonRequest))
@@ -133,7 +133,7 @@ public class BookDetailsControllerTest {
 		updatedBookDetails.setCategories(new ArrayList<BookCategory>());
 
 		String jsonRequest = mapper.writeValueAsString(updatedDTO);
-		when(service.updateBookDetails(1L, updatedDTO)).thenReturn(updatedBookDetails);
+		//when(service.updateBookDetails(1L, updatedDTO)).thenReturn(updatedBookDetails);
 		mockMvc.perform(post(BASE_URL + Mappings.UPDATE, 1L)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(jsonRequest))


### PR DESCRIPTION
Suggestion to correct validation.
Previously, we only used validation on the DTO.
At the time of adding entities as an object with incorrect data, BE received 500.
An example is e.g. BookDetails which contains the field Authors (not DTO).
An error in its parameters causes an exception.